### PR TITLE
Extract components instead of labels

### DIFF
--- a/morphology-similarity/processing/utils.py
+++ b/morphology-similarity/processing/utils.py
@@ -21,7 +21,9 @@ def extract_components(image, binarize=True, background=-1):
     if binarize:
         image = (image > 0.5).astype(int)
     labeled_sample = measure.label(image, background=background)
-    for component in np.unique(labeled_sample):
+    for label in np.unique(labeled_sample):
+        # separate each component out
+        component = (labeled_sample == label).astype(np.float64)
         if not (component == 0).all():
             # if the entire image isn't all blank, collect it
             components.append(component)


### PR DESCRIPTION
@nathanmargaglio I think this function should be extracting individual components rather than component labels from the labeled image.

Upon trying to understand your implementation of this function, it seems your logic also expects a similar output. Just take a look. If this change is not required. you can reject the PR.